### PR TITLE
Add validation for subscription pagination parameters

### DIFF
--- a/src/main/java/com/example/weather/controller/SubscriptionController.java
+++ b/src/main/java/com/example/weather/controller/SubscriptionController.java
@@ -5,9 +5,12 @@ import com.example.weather.model.SubscriptionDto;
 import com.example.weather.model.SubscriptionRequest;
 import com.example.weather.service.SubscriptionService;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import org.springframework.data.domain.Page;
@@ -16,6 +19,7 @@ import org.springframework.data.domain.PageRequest;
 @RestController
 @RequestMapping("/api/subscriptions")
 @RequiredArgsConstructor
+@Validated
 public class SubscriptionController {
 
     private final SubscriptionService service;
@@ -28,11 +32,8 @@ public class SubscriptionController {
     }
 
     @GetMapping
-    public Page<SubscriptionDto> list(@RequestParam(defaultValue = "0") int page,
-                                      @RequestParam(defaultValue = "20") int size) {
-        if (size > 100) {
-            throw new IllegalArgumentException("Page size must be between 1 and 100");
-        }
+    public Page<SubscriptionDto> list(@RequestParam(defaultValue = "0") @Min(0) int page,
+                                      @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size) {
         var pageable = PageRequest.of(page, size);
         return service.findAll(pageable)
                 .map(service::toDto);

--- a/src/test/java/com/example/weather/controller/SubscriptionControllerTest.java
+++ b/src/test/java/com/example/weather/controller/SubscriptionControllerTest.java
@@ -14,6 +14,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -58,5 +59,23 @@ class SubscriptionControllerTest {
                 .andExpect(jsonPath("$.id").value(1))
                 .andExpect(jsonPath("$.email").value("test@example.com"))
                 .andExpect(jsonPath("$.city").value("Kyiv"));
+    }
+
+    @Test
+    void listSubscriptionsPageNegativeReturnsBadRequest() throws Exception {
+        mockMvc.perform(get("/api/subscriptions").param("page", "-1"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void listSubscriptionsSizeLessThanOneReturnsBadRequest() throws Exception {
+        mockMvc.perform(get("/api/subscriptions").param("size", "0"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void listSubscriptionsSizeGreaterThanHundredReturnsBadRequest() throws Exception {
+        mockMvc.perform(get("/api/subscriptions").param("size", "101"))
+                .andExpect(status().isBadRequest());
     }
 }


### PR DESCRIPTION
## Summary
- enforce `page >= 0` and `1 <= size <= 100` in `SubscriptionController`
- add tests verifying invalid pagination parameters are rejected

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b355b4d4832e8f9d05a65277710f