### PR TITLE
Add tests for listing and deleting subscriptions

### DIFF
--- a/src/test/java/com/example/weather/controller/SubscriptionControllerTest.java
+++ b/src/test/java/com/example/weather/controller/SubscriptionControllerTest.java
@@ -4,17 +4,24 @@ import com.example.weather.model.Subscription;
 import com.example.weather.model.SubscriptionDto;
 import com.example.weather.model.SubscriptionRequest;
 import com.example.weather.service.SubscriptionService;
+import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.List;
+
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(controllers = SubscriptionController.class)
@@ -58,5 +65,54 @@ class SubscriptionControllerTest {
                 .andExpect(jsonPath("$.id").value(1))
                 .andExpect(jsonPath("$.email").value("test@example.com"))
                 .andExpect(jsonPath("$.city").value("Kyiv"));
+    }
+
+    @Test
+    void listSubscriptions() throws Exception {
+        Subscription s1 = new Subscription();
+        s1.setId(1L);
+        s1.setEmail("user1@example.com");
+        s1.setCity("Kyiv");
+
+        Subscription s2 = new Subscription();
+        s2.setId(2L);
+        s2.setEmail("user2@example.com");
+        s2.setCity("Lviv");
+
+        Page<Subscription> page = new PageImpl<>(List.of(s1, s2), PageRequest.of(0, 2), 2);
+
+        when(service.findAll(any(Pageable.class))).thenReturn(page);
+        when(service.toDto(s1)).thenReturn(new SubscriptionDto(1L, "user1@example.com", "Kyiv"));
+        when(service.toDto(s2)).thenReturn(new SubscriptionDto(2L, "user2@example.com", "Lviv"));
+
+        mockMvc.perform(get("/api/subscriptions")
+                        .param("page", "0")
+                        .param("size", "2"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.content.length()").value(2))
+                .andExpect(jsonPath("$.content[0].id").value(1))
+                .andExpect(jsonPath("$.content[1].city").value("Lviv"))
+                .andExpect(jsonPath("$.totalElements").value(2));
+    }
+
+    @Test
+    void deleteSubscription() throws Exception {
+        doNothing().when(service).delete(1L);
+
+        mockMvc.perform(delete("/api/subscriptions/{id}", 1L))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void deleteSubscriptionNotFound() throws Exception {
+        doThrow(new EntityNotFoundException("Subscription not found with id 99"))
+                .when(service).delete(99L);
+
+        mockMvc.perform(delete("/api/subscriptions/{id}", 99L))
+                .andExpect(status().isNotFound())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message").value("Subscription not found with id 99"))
+                .andExpect(jsonPath("$.errorCode").value("NOT_FOUND"));
     }
 }


### PR DESCRIPTION
## Summary
- add pagination retrieval test
- add delete endpoint tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.example:weather-app:0.0.1-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8bfe0640c832e83564aae121ec4c2