### PR TITLE
test: log mail failure with recipient

### DIFF
--- a/src/test/java/com/example/weather/service/NotificationServiceTest.java
+++ b/src/test/java/com/example/weather/service/NotificationServiceTest.java
@@ -1,10 +1,15 @@
 package com.example.weather.service;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mail.MailSendException;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.test.context.TestPropertySource;
@@ -40,6 +45,26 @@ class NotificationServiceTest {
 
         assertThatThrownBy(() -> service.send("to@example.com", "msg").join())
                 .hasCause(ex);
+    }
+
+    @Test
+    void logContainsRecipientWhenSendFails() {
+        MailSendException ex = new MailSendException("boom");
+        doThrow(ex).when(mailSender).send(any(SimpleMailMessage.class));
+
+        Logger logger = (Logger) LoggerFactory.getLogger(NotificationService.class);
+        ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+        listAppender.start();
+        logger.addAppender(listAppender);
+
+        assertThatThrownBy(() -> service.send("to@example.com", "msg").join())
+                .hasCause(ex);
+
+        assertThat(listAppender.list)
+                .extracting(ILoggingEvent::getFormattedMessage)
+                .anyMatch(msg -> msg.contains("to@example.com"));
+
+        logger.detachAppender(listAppender);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add logback ListAppender test to verify recipient address is logged when mail sending fails

## Testing
- `./mvnw -q test` *(fails: Network is unreachable: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cf05f67c832ea28e93f0c3bced9f