### PR TITLE
Add OpenAPI documentation with Swagger UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ To use an in-memory H2 database, run the application with the `dev` profile:
 ./mvnw spring-boot:run -Dspring-boot.run.profiles=dev
 ```
 
+### Swagger UI
+
+When the application is running, interactive API documentation is available at:
+
+```
+http://localhost:8080/swagger-ui.html
+```
+
 ## Environment Variables
 
 ### Database

--- a/pom.xml
+++ b/pom.xml
@@ -59,10 +59,16 @@
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
+
+                <dependency>
+                        <groupId>org.springdoc</groupId>
+                        <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+                        <version>2.5.0</version>
+                </dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/example/weather/controller/SubscriptionController.java
+++ b/src/main/java/com/example/weather/controller/SubscriptionController.java
@@ -12,24 +12,29 @@ import org.springframework.web.bind.annotation.*;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 @RestController
 @RequestMapping("/api/subscriptions")
 @RequiredArgsConstructor
+@Tag(name = "Subscriptions")
 public class SubscriptionController {
 
     private final SubscriptionService service;
 
 
     @PostMapping
+    @Operation(summary = "Create subscription")
     public ResponseEntity<SubscriptionDto> subscribe(@Valid @RequestBody SubscriptionRequest request) {
         Subscription subscription = service.create(request);
         return new ResponseEntity<>(service.toDto(subscription), HttpStatus.CREATED);
     }
 
     @GetMapping
+    @Operation(summary = "List subscriptions")
     public Page<SubscriptionDto> list(@RequestParam(defaultValue = "0") int page,
-                                      @RequestParam(defaultValue = "20") int size) {
+                                       @RequestParam(defaultValue = "20") int size) {
         if (size > 100) {
             throw new IllegalArgumentException("Page size must be between 1 and 100");
         }
@@ -40,6 +45,7 @@ public class SubscriptionController {
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "Delete subscription")
     public void delete(@PathVariable Long id) {
         service.delete(id);
     }

--- a/src/main/java/com/example/weather/model/ErrorResponse.java
+++ b/src/main/java/com/example/weather/model/ErrorResponse.java
@@ -3,12 +3,16 @@ package com.example.weather.model;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "Error details")
 public class ErrorResponse {
+    @Schema(description = "Human-readable error message")
     private String message;
+    @Schema(description = "Application-specific error code")
     private String errorCode;
 }
 

--- a/src/main/java/com/example/weather/model/SubscriptionDto.java
+++ b/src/main/java/com/example/weather/model/SubscriptionDto.java
@@ -3,12 +3,17 @@ package com.example.weather.model;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "Subscription data")
 public class SubscriptionDto {
+    @Schema(description = "Unique identifier")
     private Long id;
+    @Schema(description = "Subscriber email address")
     private String email;
+    @Schema(description = "City for weather updates")
     private String city;
 }

--- a/src/main/java/com/example/weather/model/SubscriptionRequest.java
+++ b/src/main/java/com/example/weather/model/SubscriptionRequest.java
@@ -5,15 +5,19 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "Subscription request")
 public class SubscriptionRequest {
     @Email
     @NotBlank
+    @Schema(description = "Subscriber email")
     private String email;
 
     @NotBlank
+    @Schema(description = "City for weather updates")
     private String city;
 }


### PR DESCRIPTION
## Summary
- integrate springdoc-openapi starter
- document subscription API endpoints with OpenAPI annotations
- describe Swagger UI endpoint in the README

## Testing
- `./mvnw test` *(fails: Could not resolve parent POM due to network being unreachable)*
- `./mvnw spring-boot:run -Dspring-boot.run.profiles=dev` *(fails: Could not resolve parent POM due to network being unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8e2f42428832e9a5db186b7be8c45