### PR TITLE
Add MailHog service for local email testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Subscriptions are persisted in PostgreSQL and database schema is managed via Fly
 docker compose up --build
 ```
 
-This launches the application and a PostgreSQL database.
+This launches the application, a PostgreSQL database, and MailHog. Open
+`http://localhost:8025` to view the MailHog inbox.
 
 ## Development
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,13 +8,20 @@ services:
       POSTGRES_PASSWORD: postgres
     ports:
       - "5432:5432"
+  mailhog:
+    image: mailhog/mailhog
+    ports:
+      - "1025:1025"
+      - "8025:8025"
   app:
     build: .
     environment:
       SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/weather
       SPRING_DATASOURCE_USERNAME: postgres
       SPRING_DATASOURCE_PASSWORD: postgres
+      SPRING_MAIL_HOST: mailhog
     ports:
       - "8080:8080"
     depends_on:
       - db
+      - mailhog

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -4,7 +4,7 @@ spring.jpa.hibernate.ddl-auto=update
 spring.flyway.enabled=false
 
 # use a local SMTP server like MailHog for development
-spring.mail.host=localhost
+spring.mail.host=mailhog
 spring.mail.port=1025
 spring.mail.username=
 spring.mail.password=


### PR DESCRIPTION
## Summary
- add MailHog service to docker-compose and configure Spring mail host
- default dev profile mail host to MailHog
- document access to MailHog inbox at http://localhost:8025

## Testing
- `mvn test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9574b002c832e901c0476245787c5