### PR TITLE
Add Testcontainers integration test with MailHog and Postgres

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,10 +17,11 @@
 	<name>WeatherApp</name>
 	<description>Demo project for Spring Boot</description>
 
-	<properties>
-		<java.version>21</java.version>
-		<lombok.version>1.18.32</lombok.version>
-	</properties>
+        <properties>
+                <java.version>21</java.version>
+                <lombok.version>1.18.32</lombok.version>
+                <testcontainers.version>1.19.7</testcontainers.version>
+        </properties>
 
 	<dependencies>
         <dependency>
@@ -93,11 +94,32 @@
 			<optional>true</optional>
 		</dependency>
 
-		<dependency>
-			<groupId>com.h2database</groupId>
-			<artifactId>h2</artifactId>
-			<scope>test</scope>
-		</dependency>
+                <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <scope>test</scope>
+                </dependency>
+
+                <dependency>
+                        <groupId>org.testcontainers</groupId>
+                        <artifactId>junit-jupiter</artifactId>
+                        <version>${testcontainers.version}</version>
+                        <scope>test</scope>
+                </dependency>
+
+                <dependency>
+                        <groupId>org.testcontainers</groupId>
+                        <artifactId>postgresql</artifactId>
+                        <version>${testcontainers.version}</version>
+                        <scope>test</scope>
+                </dependency>
+
+                <dependency>
+                        <groupId>org.testcontainers</groupId>
+                        <artifactId>mailhog</artifactId>
+                        <version>${testcontainers.version}</version>
+                        <scope>test</scope>
+                </dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/test/java/com/example/weather/SubscriptionControllerIT.java
+++ b/src/test/java/com/example/weather/SubscriptionControllerIT.java
@@ -1,0 +1,73 @@
+package com.example.weather;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.web.client.RestTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mailhog.MailHogContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+@SpringBootTest(classes = SubscriptionControllerIT.TestConfig.class)
+class SubscriptionControllerIT {
+
+    @SpringBootConfiguration
+    @EnableAutoConfiguration
+    static class TestConfig {
+    }
+
+    @Container
+    static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @Container
+    static final MailHogContainer mailhog = new MailHogContainer();
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.mail.host", mailhog::getHost);
+        registry.add("spring.mail.port", () -> mailhog.getMappedPort(1025));
+        registry.add("spring.flyway.enabled", () -> "false");
+    }
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private JavaMailSender mailSender;
+
+    @Test
+    void shouldSendEmailThroughMailhog() {
+        Integer result = jdbcTemplate.queryForObject("SELECT 1", Integer.class);
+        assertThat(result).isEqualTo(1);
+
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo("test@example.com");
+        message.setSubject("Test");
+        message.setText("Hello");
+        mailSender.send(message);
+
+        RestTemplate restTemplate = new RestTemplate();
+        String url = "http://" + mailhog.getHost() + ":" + mailhog.getMappedPort(8025) + "/api/v2/messages";
+        Map<String, Object> response = restTemplate.getForObject(url, Map.class);
+        List<?> items = (List<?>) response.get("items");
+        assertThat(items).isNotEmpty();
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Testcontainers dependencies for Postgres, MailHog, and JUnit
- create SubscriptionControllerIT to verify email delivery via MailHog and database access via Postgres

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b958d60410832e8a1ea26bc980569c