### PR TITLE
Expand tests for subscription and error handling

### DIFF
--- a/src/test/java/com/example/weather/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/example/weather/GlobalExceptionHandlerTest.java
@@ -18,7 +18,7 @@ class GlobalExceptionHandlerTest {
     private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
 
     @Test
-    void handleEntityNotFound() throws Exception {
+    void handleEntityNotFound() throws NoSuchMethodException {
         EntityNotFoundException ex = new EntityNotFoundException("not found");
 
         ErrorResponse response = handler.handleEntityNotFound(ex);
@@ -46,7 +46,7 @@ class GlobalExceptionHandlerTest {
     }
 
     @Test
-    void handleValidationErrors() throws Exception {
+    void handleValidationErrors() throws NoSuchMethodException {
         BeanPropertyBindingResult bindingResult = new BeanPropertyBindingResult(new Object(), "obj");
         bindingResult.addError(new FieldError("obj", "email", "must not be blank"));
         bindingResult.addError(new FieldError("obj", "city", "must not be blank"));
@@ -65,6 +65,18 @@ class GlobalExceptionHandlerTest {
                 .getAnnotation(ResponseStatus.class);
         assertNotNull(status);
         assertEquals(HttpStatus.BAD_REQUEST, status.value());
+    }
+
+    @Test
+    void handleIllegalArgumentConflict() {
+        IllegalArgumentException ex = new IllegalArgumentException("already exists");
+
+        ResponseEntity<ErrorResponse> entity = handler.handleIllegalArgument(ex);
+
+        assertEquals(HttpStatus.CONFLICT, entity.getStatusCode());
+        assertNotNull(entity.getBody());
+        assertEquals("already exists", entity.getBody().getMessage());
+        assertEquals(HttpStatus.CONFLICT.name(), entity.getBody().getErrorCode());
     }
 
     @SuppressWarnings("unused")

--- a/src/test/java/com/example/weather/controller/SubscriptionControllerTest.java
+++ b/src/test/java/com/example/weather/controller/SubscriptionControllerTest.java
@@ -14,7 +14,6 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
-import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
@@ -33,10 +32,6 @@ class SubscriptionControllerTest {
 
     @MockBean
     private SubscriptionService service;
-
-    // Щоб контекст зібрався, якщо NotificationService підтягує JavaMailSender
-    @MockBean
-    private JavaMailSender mailSender;
 
     @Test
     void createSubscription() throws Exception {
@@ -137,6 +132,16 @@ class SubscriptionControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.message").value("Page size must be between 1 and 100"))
+                .andExpect(jsonPath("$.errorCode").value("BAD_REQUEST"));
+    }
+
+    @Test
+    void listSubscriptionsNegativePage() throws Exception {
+        mockMvc.perform(get("/api/subscriptions")
+                        .param("page", "-1"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message", containsString("must not be less than zero")))
                 .andExpect(jsonPath("$.errorCode").value("BAD_REQUEST"));
     }
 

--- a/src/test/java/com/example/weather/service/NotificationServiceTest.java
+++ b/src/test/java/com/example/weather/service/NotificationServiceTest.java
@@ -14,6 +14,8 @@ import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.test.context.TestPropertySource;
 
+import java.util.concurrent.CompletableFuture;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
@@ -43,8 +45,10 @@ class NotificationServiceTest {
         RuntimeException ex = new RuntimeException("boom");
         doThrow(ex).when(mailSender).send(any(SimpleMailMessage.class));
 
-        assertThatThrownBy(() -> service.send("to@example.com", "msg").join())
-                .hasCause(ex);
+        CompletableFuture<Void> future = service.send("to@example.com", "msg");
+
+        assertThatThrownBy(future::join).hasCause(ex);
+        assertThat(future.isCompletedExceptionally()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
## Summary
- extend SubscriptionController tests with negative page validation
- add conflict scenario coverage for GlobalExceptionHandler
- ensure NotificationService test verifies failed futures

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.example:weather-app:0.0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_68bb419a0ef4832e9b1f1bee5d0f0f40