### PR TITLE
build: configure JaCoCo coverage and badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           cache: 'maven'
 
       - name: Build, test & coverage
-        run: mvn -B -ntp verify
+        run: ./mvnw -B -ntp verify
 
       - name: Upload surefire reports
         if: always()
@@ -31,6 +31,7 @@ jobs:
           path: |
             **/target/surefire-reports/**
             **/target/failsafe-reports/**
+          if-no-files-found: ignore
 
       - name: Upload JaCoCo HTML report
         if: always()

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Weather Subscription API
 
-A compact Spring Boot service that lets users **subscribe to weather updates by city** and receive email notifications.  
+[![CI](https://github.com/OWNER/weather-subscription-api/actions/workflows/ci.yml/badge.svg)](https://github.com/OWNER/weather-subscription-api/actions/workflows/ci.yml)
+[![Coverage](https://img.shields.io/badge/coverage-0%25-lightgrey)](https://github.com/OWNER/weather-subscription-api/actions/workflows/ci.yml)
+
+A compact Spring Boot service that lets users **subscribe to weather updates by city** and receive email notifications.
 Tech highlights: REST API, validation, JPA + Flyway, async mail sending, scheduled jobs, external HTTP client, Docker.
 
 ## Features

--- a/pom.xml
+++ b/pom.xml
@@ -182,10 +182,13 @@
                         <goals>
                             <goal>report</goal>
                         </goals>
+                        <configuration>
+                            <outputDirectory>${project.reporting.outputDirectory}/jacoco</outputDirectory>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
-		</plugins>
-	</build>
+                </plugins>
+        </build>
 
 </project>


### PR DESCRIPTION
## Summary
- configure JaCoCo to emit HTML coverage on `verify`
- run Maven verify in CI and archive test/coverage artifacts
- add build and coverage badges to README

## Testing
- `./mvnw -q verify` *(fails: Non-resolvable parent POM due to Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5c616074832eb53acce3228e0a5b