### PR TITLE
Explicitly configure SMTP port for Mailhog

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       SPRING_DATASOURCE_USERNAME: postgres
       SPRING_DATASOURCE_PASSWORD: postgres
       SPRING_MAIL_HOST: mailhog
+      SPRING_MAIL_PORT: 1025
     ports:
       - "8080:8080"
     depends_on:


### PR DESCRIPTION
## Summary
- Explicitly set `SPRING_MAIL_PORT` for the app service in `docker-compose.yml`

## Testing
- `./mvnw test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb643d55d8832ea5048e7cfaab1ebb