### PR TITLE
Add MapStruct mapper for subscriptions

### DIFF
--- a/src/main/java/com/example/weather/controller/SubscriptionController.java
+++ b/src/main/java/com/example/weather/controller/SubscriptionController.java
@@ -5,6 +5,7 @@ import com.example.weather.model.Subscription;
 import com.example.weather.model.SubscriptionDto;
 import com.example.weather.model.SubscriptionRequest;
 import com.example.weather.service.SubscriptionService;
+import com.example.weather.mapper.SubscriptionMapper;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -23,13 +24,14 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 public class SubscriptionController {
 
     private final SubscriptionService service;
+    private final SubscriptionMapper mapper;
 
 
     @PostMapping
     @Operation(summary = "Create subscription")
     public ResponseEntity<SubscriptionDto> subscribe(@Valid @RequestBody SubscriptionRequest request) {
         Subscription subscription = service.create(request);
-        return new ResponseEntity<>(service.toDto(subscription), HttpStatus.CREATED);
+        return new ResponseEntity<>(mapper.toDto(subscription), HttpStatus.CREATED);
     }
 
     @GetMapping
@@ -44,7 +46,7 @@ public class SubscriptionController {
         }
         var pageable = PageRequest.of(page, size);
         return service.findAll(pageable)
-                .map(service::toDto);
+                .map(mapper::toDto);
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/com/example/weather/mapper/SubscriptionMapper.java
+++ b/src/main/java/com/example/weather/mapper/SubscriptionMapper.java
@@ -1,0 +1,18 @@
+package com.example.weather.mapper;
+
+import com.example.weather.model.Subscription;
+import com.example.weather.model.SubscriptionDto;
+import com.example.weather.model.SubscriptionRequest;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface SubscriptionMapper {
+
+    SubscriptionDto toDto(Subscription subscription);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "email", expression = "java(request.getEmail().toLowerCase())")
+    Subscription toEntity(SubscriptionRequest request);
+}
+

--- a/src/main/java/com/example/weather/service/SubscriptionService.java
+++ b/src/main/java/com/example/weather/service/SubscriptionService.java
@@ -3,9 +3,9 @@ package com.example.weather.service;
 import com.example.weather.exception.BadRequestException;
 import com.example.weather.exception.NotFoundException;
 import com.example.weather.model.Subscription;
-import com.example.weather.model.SubscriptionDto;
 import com.example.weather.model.SubscriptionRequest;
 import com.example.weather.repository.SubscriptionRepository;
+import com.example.weather.mapper.SubscriptionMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
@@ -18,28 +18,17 @@ import org.springframework.transaction.annotation.Transactional;
 public class SubscriptionService {
 
     private final SubscriptionRepository repository;
-
-    public SubscriptionDto toDto(Subscription subscription) {
-        return new SubscriptionDto(
-                subscription.getId(),
-                subscription.getEmail(),
-                subscription.getCity()
-        );
-    }
+    private final SubscriptionMapper mapper;
 
     @Transactional
     public Subscription create(SubscriptionRequest request) {
-        String email = request.getEmail().toLowerCase();
+        Subscription subscription = mapper.toEntity(request);
 
-        repository.findByEmailAndCity(email, request.getCity())
+        repository.findByEmailAndCity(subscription.getEmail(), subscription.getCity())
                 .ifPresent(existing -> {
                     throw new BadRequestException("Subscription already exists for this email and city");
                 });
 
-        Subscription subscription = Subscription.builder()
-                .email(email)
-                .city(request.getCity())
-                .build();
         try {
             return repository.save(subscription);
         } catch (DataIntegrityViolationException e) {

--- a/src/test/java/com/example/weather/controller/SubscriptionControllerTest.java
+++ b/src/test/java/com/example/weather/controller/SubscriptionControllerTest.java
@@ -3,9 +3,9 @@ package com.example.weather.controller;
 import com.example.weather.exception.BadRequestException;
 import com.example.weather.exception.NotFoundException;
 import com.example.weather.model.Subscription;
-import com.example.weather.model.SubscriptionDto;
 import com.example.weather.model.SubscriptionRequest;
 import com.example.weather.service.SubscriptionService;
+import com.example.weather.mapper.SubscriptionMapperImpl;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -26,6 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.hamcrest.Matchers.containsString;
 
 @WebMvcTest(controllers = SubscriptionController.class)
+@Import(SubscriptionMapperImpl.class)
 class SubscriptionControllerTest {
 
     @Autowired
@@ -47,11 +48,8 @@ class SubscriptionControllerTest {
         saved.setEmail("test@example.com");
         saved.setCity("Kyiv");
 
-        SubscriptionDto dto = new SubscriptionDto(1L, "test@example.com", "Kyiv");
-
         // стаби для сервісу
         when(service.create(any(SubscriptionRequest.class))).thenReturn(saved);
-        when(service.toDto(saved)).thenReturn(dto);
 
         // виклик і перевірки
         mockMvc.perform(post("/api/subscriptions")
@@ -114,8 +112,6 @@ class SubscriptionControllerTest {
         Page<Subscription> page = new PageImpl<>(List.of(s1, s2), PageRequest.of(0, 2), 2);
 
         when(service.findAll(any(Pageable.class))).thenReturn(page);
-        when(service.toDto(s1)).thenReturn(new SubscriptionDto(1L, "user1@example.com", "Kyiv"));
-        when(service.toDto(s2)).thenReturn(new SubscriptionDto(2L, "user2@example.com", "Lviv"));
 
         mockMvc.perform(get("/api/subscriptions")
                         .param("page", "0")


### PR DESCRIPTION
## Summary
- introduce `SubscriptionMapper` using MapStruct for mapping between entity, DTO and request
- inject mapper into service and controller removing manual mapping code
- update tests to use the mapper implementation

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c14ec100dc832e80f93e5284f23356