### PR TITLE
Add missing Import annotation import to SubscriptionControllerTest

### DIFF
--- a/src/test/java/com/example/weather/controller/SubscriptionControllerTest.java
+++ b/src/test/java/com/example/weather/controller/SubscriptionControllerTest.java
@@ -1,5 +1,7 @@
 package com.example.weather.controller;
 
+import org.springframework.context.annotation.Import;
+
 import com.example.weather.exception.BadRequestException;
 import com.example.weather.exception.NotFoundException;
 import com.example.weather.entity.Subscription;


### PR DESCRIPTION
## Summary
- add missing `org.springframework.context.annotation.Import` import to `SubscriptionControllerTest`

## Testing
- `./mvnw -B -ntp verify` *(fails: Non-resolvable parent POM org.springframework.boot:spring-boot-starter-parent:pom:3.4.9, Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68c162a6aed0832ea4a3339e0ca4a6e0