### PR TITLE
Use problem+json content type for controller error tests

### DIFF
--- a/src/test/java/com/example/weather/controller/SubscriptionControllerTest.java
+++ b/src/test/java/com/example/weather/controller/SubscriptionControllerTest.java
@@ -74,7 +74,7 @@ class SubscriptionControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(reqJson))
                 .andExpect(status().isBadRequest())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
                 .andExpect(jsonPath("$.title").value("Bad Request"))
                 .andExpect(jsonPath("$.status").value(400))
                 .andExpect(jsonPath("$.errors.email[0]").value("must not be blank"));
@@ -93,7 +93,7 @@ class SubscriptionControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(reqJson))
                 .andExpect(status().isBadRequest())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
                 .andExpect(jsonPath("$.title").value("Bad Request"))
                 .andExpect(jsonPath("$.detail").value("Subscription already exists for this email and city"))
                 .andExpect(jsonPath("$.status").value(400));
@@ -131,7 +131,7 @@ class SubscriptionControllerTest {
         mockMvc.perform(get("/api/subscriptions")
                         .param("size", "101"))
                 .andExpect(status().isBadRequest())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
                 .andExpect(jsonPath("$.title").value("Bad Request"))
                 .andExpect(jsonPath("$.detail").value("Page size must be between 1 and 100"))
                 .andExpect(jsonPath("$.status").value(400));
@@ -142,7 +142,7 @@ class SubscriptionControllerTest {
         mockMvc.perform(get("/api/subscriptions")
                         .param("page", "-1"))
                 .andExpect(status().isBadRequest())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
                 .andExpect(jsonPath("$.title").value("Bad Request"))
                 .andExpect(jsonPath("$.detail", containsString("must not be less than zero")))
                 .andExpect(jsonPath("$.status").value(400));
@@ -163,7 +163,7 @@ class SubscriptionControllerTest {
 
         mockMvc.perform(delete("/api/subscriptions/{id}", 99L))
                 .andExpect(status().isNotFound())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
                 .andExpect(jsonPath("$.title").value("Resource not found"))
                 .andExpect(jsonPath("$.detail").value("Subscription not found with id 99"))
                 .andExpect(jsonPath("$.status").value(404));


### PR DESCRIPTION
## Summary
- Expect `application/problem+json` responses in error-handling controller tests

## Testing
- `./mvnw -B -ntp verify` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1687f7ca4832e93f40976bb352ae9