### PR TITLE
chore: update checkstyle dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,13 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>3.6.0</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.puppycrawl.tools</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>10.17.0</version>
+                    </dependency>
+                </dependencies>
                 <configuration>
                     <configLocation>checkstyle.xml</configLocation>
 


### PR DESCRIPTION
## Summary
- bump Checkstyle to 10.17.0 within maven-checkstyle-plugin

## Testing
- `./mvnw -B -ntp verify` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c16fb58874832eb1dc79ae15586cea