### PR TITLE
chore: update checkstyle engine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>10.17.0</version>
+                        <version>10.20.0</version>
                     </dependency>
                 </dependencies>
                 <configuration>


### PR DESCRIPTION
## Summary
- update maven-checkstyle-plugin's engine to Checkstyle 10.20.0

## Testing
- `./mvnw -B -ntp verify` *(fails: Non-resolvable parent POM; Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.9)*

------
https://chatgpt.com/codex/tasks/task_e_68c1723c0b84832e8c0625d7b519cdef