### PR TITLE
Use RestTemplateBuilder for WeatherClient

### DIFF
--- a/src/main/java/com/example/weather/config/WeatherConfig.java
+++ b/src/main/java/com/example/weather/config/WeatherConfig.java
@@ -5,7 +5,6 @@ import java.time.Duration;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.client.RestTemplate;
 
 /**
  * Configuration for weather-related beans.
@@ -14,17 +13,16 @@ import org.springframework.web.client.RestTemplate;
 public class WeatherConfig {
 
     /**
-     * RestTemplate configured with connect and read timeouts.
+     * RestTemplateBuilder configured with connect and read timeouts.
      *
      * @param builder RestTemplate builder
-     * @return configured RestTemplate
+     * @return configured RestTemplateBuilder
      */
     @Bean
-    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+    public RestTemplateBuilder restTemplateBuilder(RestTemplateBuilder builder) {
         return builder
                 .setConnectTimeout(Duration.ofSeconds(5))
-                .setReadTimeout(Duration.ofSeconds(5))
-                .build();
+                .setReadTimeout(Duration.ofSeconds(5));
     }
 }
 

--- a/src/main/java/com/example/weather/weather/WeatherClient.java
+++ b/src/main/java/com/example/weather/weather/WeatherClient.java
@@ -3,6 +3,7 @@ package com.example.weather.weather;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -13,8 +14,8 @@ public class WeatherClient {
 
     private final RestTemplate restTemplate;
 
-    public WeatherClient(RestTemplate restTemplate) {
-        this.restTemplate = restTemplate;
+    public WeatherClient(RestTemplateBuilder builder) {
+        this.restTemplate = builder.build();
     }
 
     public String fetchCurrentTemperature(String city) {

--- a/src/test/java/com/example/weather/weather/WeatherClientTest.java
+++ b/src/test/java/com/example/weather/weather/WeatherClientTest.java
@@ -9,6 +9,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.web.client.RestTemplate;
 
 import java.net.URI;
@@ -24,11 +25,15 @@ class WeatherClientTest {
     @Mock
     private RestTemplate restTemplate;
 
+    @Mock
+    private RestTemplateBuilder builder;
+
     private WeatherClient client;
 
     @BeforeEach
     void setUp() {
-        client = new WeatherClient(restTemplate);
+        when(builder.build()).thenReturn(restTemplate);
+        client = new WeatherClient(builder);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Build `RestTemplate` in `WeatherClient` using an injected `RestTemplateBuilder`
- Configure and expose a `RestTemplateBuilder` bean with timeouts
- Adapt tests to mock the builder instead of injecting `RestTemplate`

## Testing
- `./mvnw -B -ntp verify` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c178d79258832ea23b6c5fbe32303c