### PR TITLE
refactor: use RestClientException in catch blocks

### DIFF
--- a/src/main/java/com/example/weather/service/NotificationService.java
+++ b/src/main/java/com/example/weather/service/NotificationService.java
@@ -8,6 +8,7 @@ import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
 import java.util.concurrent.CompletableFuture;
 
 @Service
@@ -30,7 +31,7 @@ public class NotificationService {
         try {
             mailSender.send(mailMessage);
             return CompletableFuture.completedFuture(null);
-        } catch (Exception e) {
+        } catch (RestClientException e) {
             log.error("Failed to send notification to {}", email, e);
             return CompletableFuture.failedFuture(e);
         }

--- a/src/main/java/com/example/weather/weather/WeatherClient.java
+++ b/src/main/java/com/example/weather/weather/WeatherClient.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.util.UriComponentsBuilder;
 
 @Component
@@ -35,7 +36,7 @@ public class WeatherClient {
                     return temp.asText();
                 }
             }
-        } catch (Exception e) {
+        } catch (RestClientException e) {
             logger.error("Failed to fetch current temperature for city: {}", city, e);
         }
         return "n/a";


### PR DESCRIPTION
## Summary
- narrow catch blocks to RestClientException

## Testing
- `./mvnw -B -ntp verify` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.9: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c179f1340c832ea2e2fd9ddb9f45f6