### PR TITLE
Add SpotBugs annotations dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,13 @@
             <version>2.10.2</version>
             <scope>test</scope>
         </dependency>
-	</dependencies>
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <version>4.8.6</version> <!-- синхронізувати з версією плагіна -->
+            <scope>provided</scope>
+        </dependency>
+        </dependencies>
 
 
 	<build>


### PR DESCRIPTION
## Summary
- include `spotbugs-annotations` dependency in `pom.xml` so SpotBugs annotations are available during compilation

## Testing
- `./mvnw -B -ntp verify` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c17f209830832eab13499babafac7b