### PR TITLE
feat: import locale in mapper

### DIFF
--- a/src/main/java/com/example/weather/mapper/SubscriptionMapper.java
+++ b/src/main/java/com/example/weather/mapper/SubscriptionMapper.java
@@ -7,7 +7,7 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import java.util.Locale;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", imports = {Locale.class})
 public interface SubscriptionMapper {
 
     SubscriptionDto toDto(Subscription subscription);


### PR DESCRIPTION
## Summary
- import `Locale` in `SubscriptionMapper` via MapStruct

## Testing
- `./mvnw -B -ntp verify` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68c184a7463c832e9e1d0c82e93285d7