### PR TITLE
Replace RestTemplateBuilder with RestTemplate

### DIFF
--- a/src/main/java/com/example/weather/config/WeatherConfig.java
+++ b/src/main/java/com/example/weather/config/WeatherConfig.java
@@ -5,6 +5,7 @@ import java.time.Duration;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
 
 /**
  * Configuration for weather-related beans.
@@ -13,16 +14,17 @@ import org.springframework.context.annotation.Configuration;
 public class WeatherConfig {
 
     /**
-     * RestTemplateBuilder configured with connect and read timeouts.
+     * RestTemplate configured with connect and read timeouts.
      *
      * @param builder RestTemplate builder
-     * @return configured RestTemplateBuilder
+     * @return configured RestTemplate
      */
     @Bean
-    public RestTemplateBuilder restTemplateBuilder(RestTemplateBuilder builder) {
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
         return builder
                 .setConnectTimeout(Duration.ofSeconds(5))
-                .setReadTimeout(Duration.ofSeconds(5));
+                .setReadTimeout(Duration.ofSeconds(5))
+                .build();
     }
 }
 

--- a/src/main/java/com/example/weather/weather/WeatherClient.java
+++ b/src/main/java/com/example/weather/weather/WeatherClient.java
@@ -3,7 +3,6 @@ package com.example.weather.weather;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.client.RestClientException;
@@ -15,8 +14,8 @@ public class WeatherClient {
 
     private final RestTemplate restTemplate;
 
-    public WeatherClient(RestTemplateBuilder builder) {
-        this.restTemplate = builder.build();
+    public WeatherClient(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
     }
 
     public String fetchCurrentTemperature(String city) {

--- a/src/test/java/com/example/weather/weather/WeatherClientTest.java
+++ b/src/test/java/com/example/weather/weather/WeatherClientTest.java
@@ -9,7 +9,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.web.client.RestTemplate;
 
 import java.net.URI;
@@ -25,15 +24,11 @@ class WeatherClientTest {
     @Mock
     private RestTemplate restTemplate;
 
-    @Mock
-    private RestTemplateBuilder builder;
-
     private WeatherClient client;
 
     @BeforeEach
     void setUp() {
-        when(builder.build()).thenReturn(restTemplate);
-        client = new WeatherClient(builder);
+        client = new WeatherClient(restTemplate);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- provide a RestTemplate bean with timeouts in WeatherConfig
- inject RestTemplate directly into WeatherClient
- update unit test to use RestTemplate instead of builder

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c18f390608832ebb5c5607878e1c72