### PR TITLE
Configure RestTemplate bean and update WeatherClient injection

### DIFF
--- a/src/main/java/com/example/weather/config/WeatherConfig.java
+++ b/src/main/java/com/example/weather/config/WeatherConfig.java
@@ -5,6 +5,7 @@ import java.time.Duration;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
 
 /**
  * Configuration for weather-related beans.
@@ -13,16 +14,17 @@ import org.springframework.context.annotation.Configuration;
 public class WeatherConfig {
 
     /**
-     * RestTemplateBuilder configured with connect and read timeouts.
+     * RestTemplate configured with connect and read timeouts.
      *
      * @param builder default RestTemplate builder
-     * @return configured RestTemplateBuilder
+     * @return configured RestTemplate
      */
     @Bean
-    public RestTemplateBuilder restTemplateBuilder(RestTemplateBuilder builder) {
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
         return builder
                 .setConnectTimeout(Duration.ofSeconds(5))
-                .setReadTimeout(Duration.ofSeconds(5));
+                .setReadTimeout(Duration.ofSeconds(5))
+                .build();
     }
 }
 

--- a/src/main/java/com/example/weather/weather/WeatherClient.java
+++ b/src/main/java/com/example/weather/weather/WeatherClient.java
@@ -3,7 +3,6 @@ package com.example.weather.weather;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -14,8 +13,8 @@ public class WeatherClient {
 
     private final RestTemplate restTemplate;
 
-    public WeatherClient(RestTemplateBuilder builder) {
-        this.restTemplate = builder.build();
+    public WeatherClient(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
     }
 
     public String fetchCurrentTemperature(String city) {


### PR DESCRIPTION
## Summary
- create a RestTemplate bean that applies timeout configuration via the provided RestTemplateBuilder
- inject the configured RestTemplate directly into WeatherClient to avoid circular dependencies

## Testing
- ./mvnw test *(fails: Could not download Spring Boot parent POM because network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c831750c94832e9209c0d273457029