### PR TITLE
Simplify WeatherClientTest setup

### DIFF
--- a/src/test/java/com/example/weather/weather/WeatherClientTest.java
+++ b/src/test/java/com/example/weather/weather/WeatherClientTest.java
@@ -9,7 +9,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.web.client.RestTemplate;
 
 import java.net.URI;
@@ -23,16 +22,13 @@ import static org.mockito.Mockito.when;
 class WeatherClientTest {
 
     @Mock
-    private RestTemplateBuilder builder;
-    @Mock
     private RestTemplate restTemplate;
 
     private WeatherClient client;
 
     @BeforeEach
     void setUp() {
-        when(builder.build()).thenReturn(restTemplate);
-        client = new WeatherClient(builder);
+        client = new WeatherClient(restTemplate);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- update `WeatherClientTest` to inject the mocked `RestTemplate` directly
- remove the unused `RestTemplateBuilder` mock and related setup

## Testing
- `./mvnw -q test` *(fails: unable to resolve parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68c8341ea100832e9697ede170a9717b