### PR TITLE
Refactor notification service test injection

### DIFF
--- a/src/test/java/com/example/weather/service/NotificationServiceTest.java
+++ b/src/test/java/com/example/weather/service/NotificationServiceTest.java
@@ -8,11 +8,11 @@ import org.mockito.ArgumentCaptor;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mail.MailSendException;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -24,11 +24,15 @@ import static org.mockito.Mockito.*;
 @TestPropertySource(properties = "app.mail.from=sender@example.com")
 class NotificationServiceTest {
 
-    @Autowired
-    private NotificationService service;
+    private final NotificationService service;
 
-    @MockitoBean
-    private JavaMailSender mailSender;
+    private final JavaMailSender mailSender;
+
+    @Autowired
+    NotificationServiceTest(NotificationService service, @MockBean JavaMailSender mailSender) {
+        this.service = service;
+        this.mailSender = mailSender;
+    }
 
     @Test
     void sendSetsFromAddress() {


### PR DESCRIPTION
## Summary
- refactor `NotificationServiceTest` to rely on constructor injection with final fields
- register the mail sender mock through an `@MockBean` constructor parameter

## Testing
- ./mvnw -q test *(fails: unable to resolve parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68c8649bc7ec832e95c85ebc65a48963