### PR TITLE
Adjust NotificationServiceTest mail sender mock configuration

### DIFF
--- a/src/test/java/com/example/weather/service/NotificationServiceTest.java
+++ b/src/test/java/com/example/weather/service/NotificationServiceTest.java
@@ -26,10 +26,11 @@ class NotificationServiceTest {
 
     private final NotificationService service;
 
-    private final JavaMailSender mailSender;
+    @MockBean
+    private JavaMailSender mailSender;
 
     @Autowired
-    NotificationServiceTest(NotificationService service, @MockBean JavaMailSender mailSender) {
+    NotificationServiceTest(NotificationService service, JavaMailSender mailSender) {
         this.service = service;
         this.mailSender = mailSender;
     }


### PR DESCRIPTION
## Summary
- annotate the `JavaMailSender` field in `NotificationServiceTest` with `@MockBean`
- inject the mail sender via the constructor without annotations and assign it to the field

## Testing
- ./mvnw test *(fails: unable to download parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68c868b4d410832ea1258e91caff0b21