### PR TITLE
Ensure NotificationService sends asynchronously

### DIFF
--- a/src/main/java/com/example/weather/service/NotificationService.java
+++ b/src/main/java/com/example/weather/service/NotificationService.java
@@ -7,10 +7,13 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.MailException;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClientException;
+
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import org.springframework.beans.factory.annotation.Qualifier;
 
 @Service
 @RequiredArgsConstructor
@@ -19,22 +22,25 @@ public class NotificationService {
     private static final Logger log = LoggerFactory.getLogger(NotificationService.class);
     private final JavaMailSender mailSender;
 
+    @Qualifier("taskExecutor")
+    private final Executor taskExecutor;
+
     @Value("${app.mail.from:no-reply@example.com}")
     private String mailFrom;
 
-    @Async("taskExecutor")
     public CompletableFuture<Void> send(String email, String message) {
-        SimpleMailMessage mailMessage = new SimpleMailMessage();
-        mailMessage.setFrom(mailFrom);
-        mailMessage.setTo(email);
-        mailMessage.setSubject("Weather update");
-        mailMessage.setText(message);
-        try {
-            mailSender.send(mailMessage);
-            return CompletableFuture.completedFuture(null);
-        } catch (RestClientException | MailException e) {
-            log.error("Failed to send notification to {}", email, e);
-            return CompletableFuture.failedFuture(e);
-        }
+        return CompletableFuture.runAsync(() -> {
+            SimpleMailMessage mailMessage = new SimpleMailMessage();
+            mailMessage.setFrom(mailFrom);
+            mailMessage.setTo(email);
+            mailMessage.setSubject("Weather update");
+            mailMessage.setText(message);
+            try {
+                mailSender.send(mailMessage);
+            } catch (RestClientException | MailException e) {
+                log.error("Failed to send notification to {}", email, e);
+                throw e;
+            }
+        }, taskExecutor);
     }
 }


### PR DESCRIPTION
## Summary
- use injected executor with `CompletableFuture.runAsync` to dispatch notification emails
- maintain error logging and mail sender configuration

## Testing
- `mvn -q -Dtest=NotificationServiceTest#sendExecutesAsynchronously test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c86ad8f9b8832eb92e2c7f34237ac0