### PR TITLE
Use RestTemplateBuilder in WeatherClient

### DIFF
--- a/src/main/java/com/example/weather/weather/WeatherClient.java
+++ b/src/main/java/com/example/weather/weather/WeatherClient.java
@@ -3,6 +3,7 @@ package com.example.weather.weather;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -13,8 +14,8 @@ public class WeatherClient {
 
     private final RestTemplate restTemplate;
 
-    public WeatherClient(RestTemplate restTemplate) {
-        this.restTemplate = restTemplate;
+    public WeatherClient(RestTemplateBuilder builder) {
+        this.restTemplate = builder.build();
     }
 
     public String fetchCurrentTemperature(String city) {


### PR DESCRIPTION
## Summary
- update `WeatherClient` to receive a `RestTemplateBuilder`
- build a new `RestTemplate` inside the constructor to avoid reusing mutable instances

## Testing
- ./mvnw -q test *(fails: network unreachable while resolving org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68c86dd4034c832e922c230292de63ba