### PR TITLE
Update WeatherClient test to use RestTemplateBuilder

### DIFF
--- a/src/test/java/com/example/weather/weather/WeatherClientTest.java
+++ b/src/test/java/com/example/weather/weather/WeatherClientTest.java
@@ -9,6 +9,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.web.client.RestTemplate;
 
 import java.net.URI;
@@ -24,11 +25,15 @@ class WeatherClientTest {
     @Mock
     private RestTemplate restTemplate;
 
+    @Mock
+    private RestTemplateBuilder restTemplateBuilder;
+
     private WeatherClient client;
 
     @BeforeEach
     void setUp() {
-        client = new WeatherClient(restTemplate);
+        when(restTemplateBuilder.build()).thenReturn(restTemplate);
+        client = new WeatherClient(restTemplateBuilder);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- mock the RestTemplateBuilder in WeatherClientTest and use it to build the RestTemplate
- stub the RestTemplateBuilder to supply the existing RestTemplate mock when constructing WeatherClient

## Testing
- `./mvnw -q test` *(fails: unable to resolve parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68c877e07f30832eab719d9213a3d93a