### PR TITLE
Handle unexpected exceptions in WeatherClient

### DIFF
--- a/src/main/java/com/example/weather/weather/WeatherClient.java
+++ b/src/main/java/com/example/weather/weather/WeatherClient.java
@@ -40,6 +40,9 @@ public class WeatherClient {
             logger.error("Failed to fetch current temperature for city: {}", city, e);
         } catch (IllegalArgumentException e) {
             logger.error("Invalid URI while fetching current temperature for city: {}", city, e);
+        } catch (RuntimeException e) {
+            logger.error("Unexpected error while fetching current temperature for city: {}", city, e);
+            return "n/a";
         }
         return "n/a";
     }


### PR DESCRIPTION
## Summary
- add a catch-all runtime exception handler in `WeatherClient.fetchCurrentTemperature`
- log unexpected failures and ensure the method returns `"n/a"`

## Testing
- ./mvnw -q test -Dtest=WeatherClientTest *(fails: unable to resolve parent POM due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8960b3170832e942451a22de1acd5